### PR TITLE
Improved the handling of code

### DIFF
--- a/packages/html2sb-compiler/parse.js
+++ b/packages/html2sb-compiler/parse.js
@@ -69,11 +69,24 @@ function parseHeader (enlarge, context, node) {
   simpleNode.enlarge = enlarge;
 }
 
-function traditionalCodeBlock (context, node) {
+function traditionalCodeBlock(context, node) {
   context.children.push({
     type: 'code',
-    text: trim(firstChildContent(node))
+    text: collectConcatContents(node)
   });
+}
+
+function collectConcatContents(node) {
+  var contents = [];
+  if (node.content) {
+    contents.push(node.content);
+  }
+  if (node.children) {
+    node.children.forEach(function (child) {
+      contents.push(collectConcatContents(child));
+    });
+  }
+  return trim(contents.join(''));
 }
 
 function list (variant, context, node) {

--- a/packages/html2sb-compiler/parse.js
+++ b/packages/html2sb-compiler/parse.js
@@ -69,14 +69,14 @@ function parseHeader (enlarge, context, node) {
   simpleNode.enlarge = enlarge;
 }
 
-function traditionalCodeBlock(context, node) {
+function traditionalCodeBlock (context, node) {
   context.children.push({
     type: 'code',
     text: collectConcatContents(node)
   });
 }
 
-function collectConcatContents(node) {
+function collectConcatContents (node) {
   var contents = [];
   if (node.content) {
     contents.push(node.content);

--- a/packages/html2sb-compiler/test/fixtures/code.html
+++ b/packages/html2sb-compiler/test/fixtures/code.html
@@ -11,3 +11,6 @@ function bar () {}
 <code>
     warn $user-&gt;name;
 </code>
+<pre>
+    <span>user</span><span>.</span><span>name</span>
+</pre>

--- a/packages/html2sb-compiler/test/fixtures/code.html
+++ b/packages/html2sb-compiler/test/fixtures/code.html
@@ -8,3 +8,6 @@ function foo () {}
 <code>
 function bar () {}
 </code>
+<code>
+    warn $user-&gt;name;
+</code>

--- a/packages/html2sb-compiler/test/fixtures/code.json
+++ b/packages/html2sb-compiler/test/fixtures/code.json
@@ -42,6 +42,10 @@
     {
       "type": "code",
       "text": "warn $user->name;"
+    },
+    {
+      "type": "code",
+      "text": "user.name"
     }
   ]
 }

--- a/packages/html2sb-compiler/test/fixtures/code.json
+++ b/packages/html2sb-compiler/test/fixtures/code.json
@@ -38,6 +38,10 @@
     {
       "type": "code",
       "text": "function bar () {}"
+    },
+    {
+      "type": "code",
+      "text": "warn $user->name;"
     }
   ]
 }

--- a/packages/html2sb-compiler/test/fixtures/code.txt
+++ b/packages/html2sb-compiler/test/fixtures/code.txt
@@ -22,3 +22,6 @@ code:_
 
 code:_
 	function bar () {}
+
+code:_
+	warn $user->name;

--- a/packages/html2sb-compiler/test/fixtures/code.txt
+++ b/packages/html2sb-compiler/test/fixtures/code.txt
@@ -25,3 +25,6 @@ code:_
 
 code:_
 	warn $user->name;
+
+code:_
+	user.name


### PR DESCRIPTION
Some code blocks have many children. I changed `traditionalCodeBlock` to collect contents from children of node.

### before 8b233ac

```
    ⨯ code#tokens

      { title: null, children: [ { type: 'code', text: 'function myfunction (a, b) {\n  let x = a * 1.08\n  let y = b * 2\n  return x * y\n}' }, { type: 'div', children: [ { type: 'text', text: 'Hello' } ] }, { type: 'text', text: 'Holla'
 }, { type: 'code', text: 'function myfunction (a, b) {\n  let x = a * 1.08\n  let y = b * 2\n  return x * y\n}' }, { type: 'div', children: [ { type: 'text', text: 'muxa' } ] }, { type: 'code', text: 'function foo () {}' }, { type: 'code
', text: 'function bar () {}' }, { type: 'code', text: 'warn $user->name;' }, { type: 'code', text: 'user.name' } ] }

      At: testFixture (/Users/hitode909/co/github.com/pastak/scrapbox-converter/packages/html2sb-compiler/test/fixtures.js:35:45)
    ⨯ code#output

      'Untitled\ncode:_\n\tfunction myfunction (a, b) {\n\t  let x = a * 1.08\n\t  let y = b * 2\n\t  return x * y\n\t}\n\nHello\nHolla\n\ncode:_\n\tfunction myfunction (a, b) {\n\t  let x = a * 1.08\n\t  let y = b * 2\n\t  return x * y\n\t}\n\nmuxa\ncode:_\n\tfunction foo () {}\n\ncode:_\n\tfunction bar () {}\n\ncode:_\n\twarn $user->name;\n\ncode:_\n\tuser.name\n'

      At: testFixture (/Users/hitode909/co/github.com/pastak/scrapbox-converter/packages/html2sb-compiler/test/fixtures.js:40:9)
```