### PR TITLE
Support list of links - to fix bug: img in the list is not parsed

### DIFF
--- a/packages/html2sb-compiler/test/_.js
+++ b/packages/html2sb-compiler/test/_.js
@@ -1,5 +1,2 @@
-// Scroll the terminal to here
-process.stdout.write('\x1bc');
-
 // Render the date when the tests are run
 console.log('# ' + new Date());

--- a/packages/html2sb-compiler/test/fixtures.js
+++ b/packages/html2sb-compiler/test/fixtures.js
@@ -48,6 +48,7 @@ test('fixtures', function (t) {
     'code',
     'list',
     'list-in-list',
+    'list-of-links',
     'header',
     'hr',
     'table',

--- a/packages/html2sb-compiler/test/fixtures/list-of-links.html
+++ b/packages/html2sb-compiler/test/fixtures/list-of-links.html
@@ -1,0 +1,4 @@
+<ul>
+  <li><a href='http://example.com'>Example</a></li>
+  <li><img src='http://example.com/example2.png' /></li>
+</ul>

--- a/packages/html2sb-compiler/test/fixtures/list-of-links.json
+++ b/packages/html2sb-compiler/test/fixtures/list-of-links.json
@@ -1,0 +1,13 @@
+{
+  "title": null,
+  "children": [
+    {
+      "type": "list",
+      "variant": "ul",
+      "children": [
+        { "type": "text", "href": "http://example.com", "text": "Example" },
+        { "type": "img", "src": "http://example.com/example2.png" }
+      ]
+    }
+  ]
+}

--- a/packages/html2sb-compiler/test/fixtures/list-of-links.json
+++ b/packages/html2sb-compiler/test/fixtures/list-of-links.json
@@ -5,8 +5,15 @@
       "type": "list",
       "variant": "ul",
       "children": [
-        { "type": "text", "href": "http://example.com", "text": "Example" },
-        { "type": "img", "src": "http://example.com/example2.png" }
+        {
+          "type": "text",
+          "href": "http://example.com",
+          "text": "Example"
+        },
+        {
+          "type": "img",
+          "src": "http://example.com/example2.png"
+        }
       ]
     }
   ]

--- a/packages/html2sb-compiler/test/fixtures/list-of-links.txt
+++ b/packages/html2sb-compiler/test/fixtures/list-of-links.txt
@@ -1,0 +1,3 @@
+List (Untitled)
+	[http://example.com Example]
+	[http://example.com/example2.png]


### PR DESCRIPTION
I made test that fails:
[![Screenshot from Gyazo](https://gyazo.com/0ecdddf5a8172e465e5586f82dd7fad0/raw)](https://gyazo.com/0ecdddf5a8172e465e5586f82dd7fad0)