### PR TITLE
add #.extension to image src

### DIFF
--- a/packages/html2sb-compiler/test/fixtures.js
+++ b/packages/html2sb-compiler/test/fixtures.js
@@ -51,6 +51,7 @@ test('fixtures', function (t) {
     'list-of-links',
     'header',
     'hr',
+    'images',
     'table',
     'table-in-div',
     'complex',

--- a/packages/html2sb-compiler/test/fixtures/images.html
+++ b/packages/html2sb-compiler/test/fixtures/images.html
@@ -1,0 +1,3 @@
+<img src='http://example.com/example.png' />
+<br />
+<img src='http://example.com/printImage.cgi?name=bird' />

--- a/packages/html2sb-compiler/test/fixtures/images.json
+++ b/packages/html2sb-compiler/test/fixtures/images.json
@@ -1,0 +1,16 @@
+{
+  "title": null,
+  "children": [
+    {
+      "type": "img",
+      "src": "http://example.com/example.png"
+    },
+    {
+      "type": "br"
+    },
+    {
+      "type": "img",
+      "src": "http://example.com/printImage.cgi?name=bird"
+    }
+  ]
+}

--- a/packages/html2sb-compiler/test/fixtures/images.txt
+++ b/packages/html2sb-compiler/test/fixtures/images.txt
@@ -1,0 +1,3 @@
+Untitled
+[http://example.com/example.png]
+[http://example.com/printImage.cgi?name=bird#.png]

--- a/packages/html2sb-compiler/toScrapbox.js
+++ b/packages/html2sb-compiler/toScrapbox.js
@@ -11,6 +11,9 @@ function toSimpleText (node) {
     var src = '';
     if (node.src) {
       src = node.src;
+      if (!/\.(png|jpe?g|gif|svg)$/.test(src)){
+        src = src + '#.png'
+      }
     } else {
       src = 'data:' + node.mime + ';base64,' + node.data;
     }

--- a/packages/html2sb-compiler/toScrapbox.js
+++ b/packages/html2sb-compiler/toScrapbox.js
@@ -11,8 +11,8 @@ function toSimpleText (node) {
     var src = '';
     if (node.src) {
       src = node.src;
-      if (!/\.(png|jpe?g|gif|svg)$/.test(src)){
-        src = src + '#.png'
+      if (!/\.(png|jpe?g|gif|svg)$/.test(src)) {
+        src = src + '#.png';
       }
     } else {
       src = 'data:' + node.mime + ';base64,' + node.data;


### PR DESCRIPTION
Sometimes, html `<img>` tag's src does not end with extension:
sample:
`<img src="http://example.com/printImage.cgi?name=bird"/>`

In this case, converter will generate 
`[http://example.com/printImage.cgi?name=bird]` in scrapbox but this will not be rendered as images.

So I would suggest to convert them to 
`[http://example.com/printImage.cgi?name=bird#.png]`

This is well known tips in scrapbox.
