### PR TITLE
Error on style

### DIFF
--- a/packages/html2sb-compiler/parse.js
+++ b/packages/html2sb-compiler/parse.js
@@ -459,6 +459,7 @@ function parseNode (context, node) {
     console.info('Node error is happend on');
     console.info(JSON.stringify(node, null, 4));
     console.error(e);
+    throw new Error('ParseNodeError');
   }
 }
 

--- a/packages/html2sb-compiler/parse.js
+++ b/packages/html2sb-compiler/parse.js
@@ -164,7 +164,11 @@ function style (node, prop) {
     if (!node.attribs || !node.attribs.style) {
       return '';
     }
-    node.style = styleParser(node.attribs.style);
+    try {
+      node.style = styleParser(node.attribs.style);
+    } catch (e) {
+      return '';
+    }
   }
   return node.style[prop] || '';
 }


### PR DESCRIPTION
- ignore error on parsing style attribute
- should throw exception when error is happened on parsing html nodes